### PR TITLE
Don't create semaphoreci profile when it already exists

### DIFF
--- a/lib/cucumber_booster_config/cucumber_file.rb
+++ b/lib/cucumber_booster_config/cucumber_file.rb
@@ -19,8 +19,11 @@ module CucumberBoosterConfig
         puts "---"
       end
 
-      define_semaphore_profile(report_path)
-      include_semaphore_profile
+
+      unless semaphore_profile_defined? && semaphore_profile_included?
+        define_semaphore_profile(report_path)
+        include_semaphore_profile
+      end
 
       if dry_run?
         puts "Content after:"
@@ -72,6 +75,14 @@ module CucumberBoosterConfig
         puts "No definition for default profile found, inserting new one"
         @new_lines << DEFAULT_PROFILE
       end
+    end
+
+    def semaphore_profile_defined?
+      @original_lines.any? { |line| line.include?("semaphoreci:") }
+    end
+
+    def semaphore_profile_included?
+      @original_lines.any? { |line| line.include?("--profile semaphoreci") }
     end
   end
 end

--- a/spec/cucumber_booster_config/injection_spec.rb
+++ b/spec/cucumber_booster_config/injection_spec.rb
@@ -91,7 +91,8 @@ describe CucumberBoosterConfig::Injection do
         2.times { CucumberBoosterConfig::Injection.new(".", "/tmp/report_path.json").run }
 
         default_profile = File.readlines("config/cucumber.yml").first
-        expect(default_profile.count("--profile semaphoreci")).to eq(1)
+        semaphoreci_appended_profiles = default_profile.scan("--profile semaphoreci")
+        expect(semaphoreci_appended_profiles.count).to eq(1)
       end
     end
 

--- a/spec/cucumber_booster_config/injection_spec.rb
+++ b/spec/cucumber_booster_config/injection_spec.rb
@@ -30,7 +30,7 @@ describe CucumberBoosterConfig::Injection do
     end
   end
 
-  context "blank cucumber.yml in root" do
+  context "when the blank cucumber.yml is in root" do
 
     before do
       FileUtils.touch("cucumber.yml")
@@ -54,7 +54,7 @@ describe CucumberBoosterConfig::Injection do
     end
   end
 
-  context "config/cucumber.yml found" do
+  context "when config/cucumber.yml is found" do
 
     context "with a default profile" do
 
@@ -74,6 +74,24 @@ describe CucumberBoosterConfig::Injection do
         expect(lines.size).to eql(2)
         expect(lines[0].chomp).to eql("default: <%= common %> --profile semaphoreci")
         expect(lines[1].chomp).to eql("semaphoreci: --format json --out=/tmp/report_path.json")
+      end
+
+      it "doesn't create semaphoreci profile if it is already created" do
+        2.times { CucumberBoosterConfig::Injection.new(".", "/tmp/report_path.json").run }
+
+        lines = File.readlines("config/cucumber.yml")
+        semaphoreci_profiles = lines.select do |line|
+          line.chomp == "semaphoreci: --format json --out=/tmp/report_path.json"
+        end
+
+        expect(semaphoreci_profiles.count).to eq(1)
+      end
+
+      it "doesn't append semaphoreci profile to default if it is already appended" do
+        2.times { CucumberBoosterConfig::Injection.new(".", "/tmp/report_path.json").run }
+
+        default_profile = File.readlines("config/cucumber.yml").first
+        expect(default_profile.count("--profile semaphoreci")).to eq(1)
       end
     end
 


### PR DESCRIPTION
If you run Boosters multiple times on same `cucumber.yml` file Cucumber Injector creates duplicate semaphoreci profiles and append them all to the default one.

This prevents creating and appending semaphoreci profile if it already exists.