### PR TITLE
Relax thor dependency version

### DIFF
--- a/cucumber_booster_config.gemspec
+++ b/cucumber_booster_config.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "thor", "~> 0.19.1"
+  spec.add_dependency "thor", [">= 0.19.1", "< 2.0"]
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We are currently enabled to install gems that depends on recent thor releases (>= 1.0).

According to thor [changelog](https://github.com/erikhuda/thor/blob/master/CHANGELOG.md), they simply bumped to version 1.0 without backward incompatibilities.

This change relax the thor dependency version definition to allow other gems to use thor >= 1.0.